### PR TITLE
[SR-1838] Whitelist workdir in docker image to avoid git permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 COPY entrypoint.sh /entrypoint.sh
 
+RUN git config --global --add safe.directory /src
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 VOLUME /src


### PR DESCRIPTION
Fixes:
```
$ exe/rubocop --commit=develop
/usr/local/bundle/gems/pronto-0.11.2/lib/pronto/cli.rb:65:in `discover': repository path '/src/' is not owned by current user (Rugged::ConfigError)
from /usr/local/bundle/gems/pronto-0.11.2/lib/pronto/cli.rb:65:in `run'
from /usr/local/bundle/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
from /usr/local/bundle/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
from /usr/local/bundle/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
from /usr/local/bundle/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
from /usr/local/bundle/gems/pronto-0.11.2/bin/pronto:6:in `<top (required)>'
from /usr/local/bundle/bin/pronto:25:in `load'
from /usr/local/bundle/bin/pronto:25:in `<main>'
```

Setting `--user` option when running the running container does not work for all our scenarios. For example for OSX Docker desktop users with a in the middle VM.