### PR TITLE
[SR-1838] Update to rolling `pronto-rubocop` to avoid warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rubocop-i18n', '~> 3.0.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-capybara', '~> 2.21.0'
 gem 'pronto', '~> 0.11.2'
-gem 'pronto-rubocop', '~> 0.11.5'
+# Pending official 0.11.6 with  this fix: https://github.com/prontolabs/pronto-rubocop/commit/82336062b86e5b24fddb22e13c61b11286307e27
+gem 'pronto-rubocop', '~> 0.11.5', github: 'prontolabs/pronto-rubocop', ref: 'master'
 
 gem 'faraday-retry', '~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/prontolabs/pronto-rubocop.git
+  revision: 82336062b86e5b24fddb22e13c61b11286307e27
+  ref: master
+  specs:
+    pronto-rubocop (0.11.5)
+      pronto (~> 0.11.0)
+      rubocop (>= 0.63.1, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -65,9 +74,6 @@ GEM
       rexml (>= 3.2.5, < 4.0)
       rugged (>= 0.23.0, < 2.0)
       thor (>= 0.20.3, < 2.0)
-    pronto-rubocop (0.11.5)
-      pronto (~> 0.11.0)
-      rubocop (>= 0.63.1, < 2.0)
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (3.1.8)
@@ -122,7 +128,7 @@ PLATFORMS
 DEPENDENCIES
   faraday-retry (~> 2.2.1)
   pronto (~> 0.11.2)
-  pronto-rubocop (~> 0.11.5)
+  pronto-rubocop (~> 0.11.5)!
   rubocop (~> 1.69.2)
   rubocop-capybara (~> 2.21.0)
   rubocop-i18n (~> 3.0.0)


### PR DESCRIPTION
Fixes warnings:
```
/usr/local/bundle/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:34: warning: `Cop.all` is deprecated. Use `Registry.all` instead.
/usr/local/bundle/gems/pronto-rubocop-0.11.5/lib/pronto/rubocop/patch_cop.rb:62: warning: `inspect_file` is deprecated. Use `investigate` instead.
```

Fix pending to be pushed in the gem as 0.11.6: 
https://github.com/prontolabs/pronto-rubocop/commit/82336062b86e5b24fddb22e13c61b11286307e27